### PR TITLE
refactor: remove timeout parameter from httpclient

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -31,6 +31,7 @@ jobs:
 
     - name: Dep
       run: |
+        sudo apt update
         sudo apt install libtesseract-dev -y
         make dep
 

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -19,6 +19,7 @@ jobs:
 
     - name: Dep
       run: |
+        sudo apt update
         sudo apt install libtesseract-dev -y
         make dep
 

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -8,21 +8,14 @@ import (
 )
 
 // LoginConfirm 验证账号密码
-func LoginConfirm(ctx context.Context, account interface{}, timeout time.Duration) error {
-	var cc context.CancelFunc
-	ctx, cc = context.WithTimeout(ctx, timeout)
+func LoginConfirm(ctx context.Context, account interface{}) error {
 	c := newClient(ctx)
 	err := c.login(account.(*Account))
-	cc()
 	return parseURLError(err)
 }
 
 // Punch 打卡
-func Punch(ctx context.Context, account interface{}, timeout time.Duration) (err error) {
-	var cc context.CancelFunc
-	ctx, cc = context.WithTimeout(ctx, timeout)
-	defer cc()
-
+func Punch(ctx context.Context, account interface{}) (err error) {
 	defer func() {
 		err = parseURLError(err)
 	}()

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func app(ctx context.Context, ready func()) {
 	}
 
 	logger.Print("正在验证账号密码\n")
-	err = client.LoginConfirm(ctx, account, punchTimeout)
+	err = client.LoginConfirm(ctx, account)
 	if err != nil {
 		logger.Fatalf("验证密码失败(Err: %s)\n", err.Error())
 	}


### PR DESCRIPTION
Changes:

- Only using context.Context to implement timeout.
- Remove timeout setting for httpclient.LoginConfirm, the function could return the result within 10 seconds.