### PR TITLE
refactor: retry login without extra GET requests

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -21,17 +21,7 @@ func Punch(ctx context.Context, account interface{}) (err error) {
 	}()
 
 	c := newClient(ctx)
-	for i := 0; i < 3; i++ { // 重试 3 次
-		err = c.login(account.(*Account)) // 登录，获取cookie
-		switch err {
-		case ErrWrongCaptcha:
-			if wait(ctx, time.Second*2) != nil {
-				return
-			}
-		default:
-			break
-		}
-	}
+	err = c.login(account.(*Account)) // 登录，获取cookie
 	if err != nil {
 		return
 	}

--- a/httpclient/login.go
+++ b/httpclient/login.go
@@ -61,7 +61,7 @@ func (c *punchClient) login(account *Account) (err error) {
 				return
 			}
 		default:
-			break
+			return
 		}
 	}
 	return
@@ -155,7 +155,7 @@ func recognizeCaptcha(c *punchClient) (vcode string, err error) {
 
 func parseForm(body io.Reader, form *loginForm) (err error) {
 	bufferReader := bufio.NewReader(body)
-	const inputElement = "<input type=\"hidden\""
+	const inputElement = "<input "
 
 	var filler *structFiller
 	if filler, err = newFiller(form, "fill"); err != nil {

--- a/httpclient/tools.go
+++ b/httpclient/tools.go
@@ -19,6 +19,7 @@ const host = "http://smst.hhu.edu.cn"
 var generalHeaders = http.Header{
 	"Accept":          []string{"*/*"},
 	"Accept-Language": []string{"zh-CN,zh;q=0.9"},
+	"Connection":      []string{"keep-alive"},
 	"User-Agent":      []string{"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.0.0 Safari/537.36"},
 }
 

--- a/httpclient/tools.go
+++ b/httpclient/tools.go
@@ -19,7 +19,6 @@ const host = "http://smst.hhu.edu.cn"
 var generalHeaders = http.Header{
 	"Accept":          []string{"*/*"},
 	"Accept-Language": []string{"zh-CN,zh;q=0.9"},
-	"Connection":      []string{"keep-alive"},
 	"User-Agent":      []string{"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.0.0 Safari/537.36"},
 }
 


### PR DESCRIPTION
If login failed, the HTTP body will contain form data for the next POST request, parsing the form to avoid extra GET requests.