### PR TITLE
refactor: use custom value for map to avoid `interface{}`

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -44,7 +44,7 @@ func Punch(ctx context.Context, account interface{}, timeout time.Duration) (err
 	}
 
 	var (
-		form   map[string]interface{}
+		form   map[string]formValue
 		params *QueryParam
 	)
 	form, params, err = c.getFormDetail() // 获取打卡列表信息


### PR DESCRIPTION
When post a HTML form, we will only use the value (without type):

**string**:

```http
foo=bar
```

**number**:

```http
foo=1
```

So we can store all the json value into string (even for a number).

By this change, we can avoid using `interface{}` for easier to maintain.

## Reference

[Send form data on MDN](https://developer.mozilla.org/zh-CN/docs/Learn/Forms/Sending_and_retrieving_form_data).
